### PR TITLE
[kalia] - 더미데이터 삽입 후, 이슈 데이터 리스트로 전달

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/Issue.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/Issue.java
@@ -1,0 +1,39 @@
+package com.CodeSquad.IssueTracker.issues;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "issues")
+public class Issue {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "issue_id")
+    private Long id;
+
+    @Column(nullable = false, length = 60)
+    private String title;
+
+    @Column(length = 16)
+    private String author;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "is_closed")
+    private Boolean isClosed;
+
+    protected Issue() {}
+
+
+    public Issue(String title, String author) {
+        this.title = title;
+        this.author = author;
+        this.publishedAt = LocalDateTime.now();
+        this.isClosed = false;
+    }
+
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
@@ -1,0 +1,24 @@
+package com.CodeSquad.IssueTracker.issues;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@CrossOrigin(origins = "*")
+@RestController
+public class IssueController {
+    private final IssueService issueService;
+
+    public IssueController(IssueService issueService) {
+        this.issueService = issueService;
+    }
+
+    @GetMapping("/issues")
+    public ResponseEntity<List<Issue>> getAllIssues() {
+        List<Issue> issues = issueService.getAllIssues();
+        return new ResponseEntity<>(issues, HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueRepository.java
@@ -1,0 +1,6 @@
+package com.CodeSquad.IssueTracker.issues;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueRepository extends JpaRepository<Issue, Long> {
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
@@ -1,0 +1,22 @@
+package com.CodeSquad.IssueTracker.issues;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+
+@Slf4j
+@Service
+public class IssueService {
+    private final IssueRepository issueRepository;
+
+    public IssueService(IssueRepository issueRepository) {
+        this.issueRepository = issueRepository;
+    }
+
+    public List<Issue> getAllIssues() {
+        List<Issue> issues = issueRepository.findAll();
+        log.info("Retrieved issues: {}", issues);
+        return issueRepository.findAll();
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/utils/LoadDatabase.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/utils/LoadDatabase.java
@@ -1,0 +1,22 @@
+/*
+package com.CodeSquad.IssueTracker.issues.utils;
+
+import com.CodeSquad.IssueTracker.issues.Issue;
+import com.CodeSquad.IssueTracker.issues.IssueRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoadDatabase {
+    @Bean
+    CommandLineRunner initDatabase(IssueRepository repository) {
+        return args -> {
+            // 더미 데이터 추가
+            for (int i = 1; i <= 10; i++) {
+                repository.save(new Issue("Issue " + i, "Author " + i));
+            }
+        };
+    }
+}
+*/


### PR DESCRIPTION
더미데이터 삽입 후, 이슈 데이터를 리스트로 전달을 구현했습니다.

# 1. 이슈 목록 조회
|HTTP 메소드|경로|설명|반환값|
|------|---|---|---|
|GET|/get/issues|이슈 목록 반환|정상 반환: OK|