### PR TITLE
[다오] 이슈 생성 기능 추가

### DIFF
--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.CodeSquad.IssueTracker.Exception;
 
+import com.CodeSquad.IssueTracker.Exception.issue.AuthorNotFoundException;
+import com.CodeSquad.IssueTracker.Exception.issue.InvalidIssueDataException;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidCredentialException;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidUserFormatException;
 import com.CodeSquad.IssueTracker.Exception.user.UserAlreadyExistsException;
@@ -30,5 +32,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserNotLoginException.class)
     public ResponseEntity<String> handleUserNotLoginException(UserNotLoginException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(AuthorNotFoundException.class)
+    public ResponseEntity<String> handleAuthorNotFoundException(AuthorNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidIssueDataException.class)
+    public ResponseEntity<String> handleInvalidIssueDataException(InvalidIssueDataException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/issue/AuthorNotFoundException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/issue/AuthorNotFoundException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.issue;
+
+public class AuthorNotFoundException extends RuntimeException {
+    public AuthorNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/issue/InvalidIssueDataException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/issue/InvalidIssueDataException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.issue;
+
+public class InvalidIssueDataException extends RuntimeException {
+    public InvalidIssueDataException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/Issue.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/Issue.java
@@ -1,8 +1,6 @@
 package com.CodeSquad.IssueTracker.issues;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -10,8 +8,9 @@ import java.time.LocalDateTime;
 
 @Setter
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
-
+@Data
 @Table("issues")
 public class Issue {
     @Id

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class IssueController {
@@ -24,7 +25,9 @@ public class IssueController {
     }
 
     @PostMapping("/issue")
-    public void createIssue(@RequestBody IssueRequest issueRequest) {
-        issueService.createIssue(issueRequest);
+    public ResponseEntity<Map<String, Long>> createIssue(@RequestBody IssueRequest issueRequest) {
+        Long createdIssueId = issueService.createIssue(issueRequest);
+        Map<String, Long> response = Map.of("issueId", createdIssueId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
@@ -1,8 +1,11 @@
 package com.CodeSquad.IssueTracker.issues;
 
+import com.CodeSquad.IssueTracker.issues.dto.IssueRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
@@ -18,5 +21,10 @@ public class IssueController {
     public ResponseEntity<List<Issue>> getAllIssues() {
         List<Issue> issues = issueService.getAllIssues();
         return new ResponseEntity<>(issues, HttpStatus.OK);
+    }
+
+    @PostMapping("/issue")
+    public void createIssue(@RequestBody IssueRequest issueRequest) {
+        issueService.createIssue(issueRequest);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
@@ -14,9 +14,11 @@ import java.util.List;
 @Service
 public class IssueService {
     private final IssueRepository issueRepository;
+    private final CommentRepository commentRepository;
 
-    public IssueService(IssueRepository issueRepository) {
+    public IssueService(IssueRepository issueRepository, CommentRepository commentRepository) {
         this.issueRepository = issueRepository;
+        this.commentRepository = commentRepository;
     }
 
     public List<Issue> getAllIssues() {
@@ -37,5 +39,14 @@ public class IssueService {
 
         issueRepository.save(issue);
 
+        // 이슈 작성 시 입력한 내용을 첫번째 코멘트로 저장하기 위함.
+        Comment comment = new Comment();
+        comment.setAuthor(issueRequest.author());
+        comment.setContent(issueRequest.content());
+        comment.setPublishedAt(LocalDateTime.now());
+        // save 메소드가 호출된 후, @ID 식별자로 지정된 필드에 자동생성된 ID가 설정되어 이용할 수 있다.
+        comment.setIssueId(issue.getIssueId());
+
+        commentRepository.save(comment);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
@@ -1,7 +1,12 @@
 package com.CodeSquad.IssueTracker.issues;
 
+import com.CodeSquad.IssueTracker.issues.comment.Comment;
+import com.CodeSquad.IssueTracker.issues.comment.CommentRepository;
+import com.CodeSquad.IssueTracker.issues.dto.IssueRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -18,5 +23,19 @@ public class IssueService {
         List<Issue> issues = (List<Issue>) issueRepository.findAll();
         log.info("Retrieved issues: {}", issues);
         return (List<Issue>) issueRepository.findAll();
+    }
+
+    public void createIssue(IssueRequest issueRequest) {
+        log.info("Creating issue: {}", issueRequest);
+
+        // 이슈 저장을 위한 객체 생성
+        Issue issue = new Issue();
+        issue.setTitle(issueRequest.title());
+        issue.setAuthor(issueRequest.author());
+        issue.setPublishedAt(LocalDateTime.now());
+        issue.setIsClosed(false);
+
+        issueRepository.save(issue);
+
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueService.java
@@ -27,7 +27,7 @@ public class IssueService {
         return (List<Issue>) issueRepository.findAll();
     }
 
-    public void createIssue(IssueRequest issueRequest) {
+    public Long createIssue(IssueRequest issueRequest) {
         log.info("Creating issue: {}", issueRequest);
 
         // 이슈 저장을 위한 객체 생성
@@ -48,5 +48,7 @@ public class IssueService {
         comment.setIssueId(issue.getIssueId());
 
         commentRepository.save(comment);
+
+        return issue.getIssueId();
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/comment/Comment.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/comment/Comment.java
@@ -1,0 +1,18 @@
+package com.CodeSquad.IssueTracker.issues.comment;
+
+import lombok.Data;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Data
+@Table("comments")
+public class Comment {
+    @Id
+    private Long commentId;
+    private Long issueId;
+    private String content;
+    private String author;
+    private LocalDateTime publishedAt;
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/comment/CommentRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/comment/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.CodeSquad.IssueTracker.issues.comment;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface CommentRepository extends CrudRepository<Comment, Long>{
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueRequest.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueRequest.java
@@ -1,0 +1,12 @@
+package com.CodeSquad.IssueTracker.issues.dto;
+
+import java.util.List;
+
+public record IssueRequest(
+        String title,
+        String content,
+        String author,
+        List<String> assignees,
+        List<String> labels,
+        String milestone
+) {}


### PR DESCRIPTION
### 이슈 작성
- [x] Issue ( 제목, 작성자, 작성시간, 오픈여부 ) 를 저장할 수 있다.
- [x] 이슈의 본문 (content) 를 comments 테이블에 저장할 수 있다.
- [x] 작성된 이슈 조회 페이지로의 리다이렉트를 위한 issueId 반환을 할 수 있다.
  - CrudRepository.save 의 결과로 @ID 식별자로 지정된 issueId 필드가 채워지고 이를 반환하도록 합니다.
- [x] 전달받은 데이터의 유효성을 검사하고 처리할 수 있다.
  - 작성자가 Users 테이블에 존재하는 유저인지 확인
  - 제목과 내용이 모두 존재하는지 확인

### 사용된 API
| 요청          | 행동        |
|-------------|-----------|
| POST /issue | 새로운 이슈 생성 |

