### PR TITLE
[Kalia] - 라벨 생성 기능 추가

### DIFF
--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
@@ -1,8 +1,6 @@
 package com.CodeSquad.IssueTracker.Exception;
 
-import com.CodeSquad.IssueTracker.Exception.label.EmptyLabelNameException;
-import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelColorException;
-import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelIdException;
+import com.CodeSquad.IssueTracker.Exception.label.*;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidCredentialException;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidUserFormatException;
 import com.CodeSquad.IssueTracker.Exception.user.UserAlreadyExistsException;
@@ -46,6 +44,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidLabelColorException.class)
     public ResponseEntity<String> handleInvalidLabelColorException(InvalidLabelColorException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+    @ExceptionHandler(LabelNotFoundException.class)
+    public ResponseEntity<String> handleLabelNotFoundException(LabelNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(LabelUpdateException.class)
+    public ResponseEntity<String> handleLabelUpdateException(LabelUpdateException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.CodeSquad.IssueTracker.Exception;
 
+import com.CodeSquad.IssueTracker.Exception.label.EmptyLabelNameException;
+import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelColorException;
+import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelIdException;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidCredentialException;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidUserFormatException;
 import com.CodeSquad.IssueTracker.Exception.user.UserAlreadyExistsException;
@@ -30,5 +33,19 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserNotLoginException.class)
     public ResponseEntity<String> handleUserNotLoginException(UserNotLoginException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+    @ExceptionHandler(InvalidLabelIdException.class)
+    public ResponseEntity<String> handleInvalidLabelIdException(InvalidLabelIdException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(EmptyLabelNameException.class)
+    public ResponseEntity<String> handleEmptyLabelNameException(EmptyLabelNameException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidLabelColorException.class)
+    public ResponseEntity<String> handleInvalidLabelColorException(InvalidLabelColorException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/EmptyLabelNameException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/EmptyLabelNameException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.label;
+
+public class EmptyLabelNameException extends RuntimeException {
+    public EmptyLabelNameException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/InvalidLabelColorException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/InvalidLabelColorException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.label;
+
+public class InvalidLabelColorException extends RuntimeException {
+    public InvalidLabelColorException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/InvalidLabelIdException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/InvalidLabelIdException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.label;
+
+public class InvalidLabelIdException extends RuntimeException {
+    public InvalidLabelIdException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/LabelNotFoundException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/LabelNotFoundException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.label;
+
+public class LabelNotFoundException extends RuntimeException {
+    public LabelNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/LabelUpdateException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/label/LabelUpdateException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.label;
+
+public class LabelUpdateException extends RuntimeException {
+    public LabelUpdateException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/Label.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/Label.java
@@ -1,0 +1,48 @@
+package com.CodeSquad.IssueTracker.labels;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Getter
+@Setter
+@Table("labels")
+public class Label implements Persistable<Long> {
+
+    @Id
+    private Long labelId;
+
+    private String labelName;
+
+    private String description;
+
+    private String textColor;
+
+    private String bgColor;
+
+    @Transient
+    private boolean isNew = true;
+
+    public Label() {}
+
+    @Override
+    public Long getId() {
+        return labelId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    public Label(Long labelId, String labelName, String description, String textColor, String bgColor) {
+        this.labelId = labelId;
+        this.labelName = labelName;
+        this.description = description;
+        this.textColor = textColor;
+        this.bgColor = bgColor;
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelController.java
@@ -1,0 +1,28 @@
+package com.CodeSquad.IssueTracker.labels;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+public class LabelController {
+
+    @Autowired
+    private LabelService labelService;
+
+    @GetMapping("/labels")
+    public ResponseEntity<List<Label>> getAllLabels() {
+        List<Label> labels = labelService.getAllLabels();
+        return ResponseEntity.ok(labels);
+    }
+
+    @PostMapping("/label")
+    public ResponseEntity<Label> createLabel(@RequestBody Label label) {
+        Label createdLabel = labelService.createLabel(label);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdLabel);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelController.java
@@ -25,4 +25,23 @@ public class LabelController {
         Label createdLabel = labelService.createLabel(label);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdLabel);
     }
+
+    @GetMapping("/label/{id}")
+    public ResponseEntity<Label> getLabelById(@PathVariable Long id) {
+        Optional<Label> label = labelService.getLabelById(id);
+        return label.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/label/{id}")
+    public ResponseEntity<Label> updateLabel(@PathVariable Long id, @RequestBody Label updatedLabel) {
+        Label updatedLabelResponse = labelService.updateLabel(id, updatedLabel);
+        return updatedLabelResponse != null ? ResponseEntity.ok(updatedLabelResponse) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/label/{id}")
+    public ResponseEntity<Void> deleteLabel(@PathVariable Long id) {
+        labelService.deleteLabel(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelRepository.java
@@ -1,0 +1,8 @@
+package com.CodeSquad.IssueTracker.labels;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LabelRepository extends CrudRepository<Label, Long> {
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
@@ -1,0 +1,28 @@
+package com.CodeSquad.IssueTracker.labels;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class LabelService {
+
+    @Autowired
+    private LabelRepository labelRepository;
+
+    public List<Label> getAllLabels() {
+        return (List<Label>) labelRepository.findAll();
+    }
+
+    public Optional<Label> getLabelById(Long id) {
+        return labelRepository.findById(id);
+    }
+
+    public Label createLabel(Label label) {
+        label.setNew(true);
+        return labelRepository.save(label);
+    }
+
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
@@ -1,5 +1,6 @@
 package com.CodeSquad.IssueTracker.labels;
 
+import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelIdException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,9 @@ public class LabelService {
     }
 
     public Optional<Label> getLabelById(Long id) {
+        if (id <= 0) {
+            throw new InvalidLabelIdException("유효하지 않은 라벨 ID: " + id);
+        }
         log.info("라벨 id: {} 조회 요청", id);
         return labelRepository.findById(id);
     }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
@@ -1,6 +1,7 @@
 package com.CodeSquad.IssueTracker.labels;
 
 import com.CodeSquad.IssueTracker.Exception.label.InvalidLabelIdException;
+import com.CodeSquad.IssueTracker.Exception.label.LabelNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,23 +37,21 @@ public class LabelService {
 
     public Label updateLabel(Long id, Label updatedLabel) {
         log.info("라벨 id: {} 업데이트 요청: {}", id, updatedLabel);
-        Optional<Label> existingLabel = labelRepository.findById(id);
-        if (existingLabel.isPresent()) {
-            Label label = existingLabel.get();
-            label.setLabelName(updatedLabel.getLabelName());
-            label.setDescription(updatedLabel.getDescription());
-            label.setTextColor(updatedLabel.getTextColor());
-            label.setBgColor(updatedLabel.getBgColor());
-            label.setNew(false);
-            return labelRepository.save(label);
-        }
-        log.warn("라벨 id: {} 업데이트 실패, 해당 라벨이 존재하지 않습니다.", id);
-        return null;
+        return labelRepository.findById(id).map(existingLabel -> {
+            existingLabel.setLabelName(updatedLabel.getLabelName());
+            existingLabel.setDescription(updatedLabel.getDescription());
+            existingLabel.setTextColor(updatedLabel.getTextColor());
+            existingLabel.setBgColor(updatedLabel.getBgColor());
+            existingLabel.setNew(false);
+            return labelRepository.save(existingLabel);
+        }).orElseThrow(() -> new LabelNotFoundException("라벨 id: " + id + " 업데이트 실패, 해당 라벨이 존재하지 않습니다."));
     }
 
     public void deleteLabel(Long id) {
         log.info("라벨 id: {} 삭제 요청", id);
+        if (!labelRepository.existsById(id)) {
+            throw new LabelNotFoundException("라벨 id: " + id + " 삭제 실패, 해당 라벨이 존재하지 않습니다.");
+        }
         labelRepository.deleteById(id);
     }
-
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
@@ -1,11 +1,13 @@
 package com.CodeSquad.IssueTracker.labels;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @Service
 public class LabelService {
 
@@ -13,18 +15,23 @@ public class LabelService {
     private LabelRepository labelRepository;
 
     public List<Label> getAllLabels() {
+        log.info("모든 라벨 조회 요청");
         return (List<Label>) labelRepository.findAll();
     }
 
     public Optional<Label> getLabelById(Long id) {
+        log.info("라벨 id: {} 조회 요청", id);
         return labelRepository.findById(id);
     }
 
     public Label createLabel(Label label) {
+        log.info("새 라벨 생성 요청: {}", label);
         label.setNew(true);
         return labelRepository.save(label);
     }
+
     public Label updateLabel(Long id, Label updatedLabel) {
+        log.info("라벨 id: {} 업데이트 요청: {}", id, updatedLabel);
         Optional<Label> existingLabel = labelRepository.findById(id);
         if (existingLabel.isPresent()) {
             Label label = existingLabel.get();
@@ -35,10 +42,12 @@ public class LabelService {
             label.setNew(false);
             return labelRepository.save(label);
         }
+        log.warn("라벨 id: {} 업데이트 실패, 해당 라벨이 존재하지 않습니다.", id);
         return null;
     }
 
     public void deleteLabel(Long id) {
+        log.info("라벨 id: {} 삭제 요청", id);
         labelRepository.deleteById(id);
     }
 

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/labels/LabelService.java
@@ -24,5 +24,22 @@ public class LabelService {
         label.setNew(true);
         return labelRepository.save(label);
     }
+    public Label updateLabel(Long id, Label updatedLabel) {
+        Optional<Label> existingLabel = labelRepository.findById(id);
+        if (existingLabel.isPresent()) {
+            Label label = existingLabel.get();
+            label.setLabelName(updatedLabel.getLabelName());
+            label.setDescription(updatedLabel.getDescription());
+            label.setTextColor(updatedLabel.getTextColor());
+            label.setBgColor(updatedLabel.getBgColor());
+            label.setNew(false);
+            return labelRepository.save(label);
+        }
+        return null;
+    }
+
+    public void deleteLabel(Long id) {
+        labelRepository.deleteById(id);
+    }
 
 }


### PR DESCRIPTION
더미데이터 삽입 후, 이슈 데이터를 리스트로 전달을 구현했습니다.

# 1. API
|HTTP 메소드|경로|설명|반환값|
|------|---|---|---|
|GET|/labels|모든 라벨 목록 반환|정상 반환: OK|
|POST|/label|새 라벨 생성|정상 반환: CREATED|
|GET|/label/{id}|지정된 ID의 라벨 조회|정상 반환: OK, 실패: NOT FOUND|
|PUT|/label/{id}|지정된 ID의 라벨 업데이트|정상 반환: OK, 실패: NOT FOUND|
|DELETE|/label/{id}|지정된 ID의 라벨 삭제|정상 반환: NO CONTENT|

# 2. 구현 Service 메소드 요약

## 모든 라벨 조회 (`getAllLabels`)
- **메소드 설명**: 시스템에 저장된 모든 라벨을 조회합니다.
- **입력 파라미터**: 없음
- **반환 값**: `List<Label>` - 조회된 라벨 목록

## 라벨 ID로 조회 (`getLabelById`)
- **메소드 설명**: 주어진 ID를 가진 라벨을 조회합니다. ID가 유효하지 않은 경우 `InvalidLabelIdException`을 발생시킵니다.
- **입력 파라미터**: `Long id` - 조회할 라벨의 ID
- **반환 값**: `Optional<Label>` - 조회된 라벨

## 라벨 생성 (`createLabel`)
- **메소드 설명**: 새로운 라벨을 생성합니다.
- **입력 파라미터**: `Label label` - 생성할 라벨 정보
- **반환 값**: `Label` - 생성된 라벨

## 라벨 업데이트 (`updateLabel`)
- **메소드 설명**: 주어진 ID를 가진 라벨의 정보를 업데이트합니다. 해당 ID의 라벨이 존재하지 않을 경우 `LabelNotFoundException`을 발생시킵니다.
- **입력 파라미터**:
  - `Long id` - 업데이트할 라벨의 ID
  - `Label updatedLabel` - 업데이트할 라벨 정보
- **반환 값**: `Label` - 업데이트된 라벨

## 라벨 삭제 (`deleteLabel`)
- **메소드 설명**: 주어진 ID를 가진 라벨을 삭제합니다. 해당 ID의 라벨이 존재하지 않을 경우 `LabelNotFoundException`을 발생시킵니다.
- **입력 파라미터**: `Long id` - 삭제할 라벨의 ID
- **반환 값**: 없음