### PR TITLE
[미르] - 마일스톤 관련 기능 추가 및 유저 에러 관련 수정

### DIFF
--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/GlobalExceptionHandler.java
@@ -1,9 +1,8 @@
 package com.CodeSquad.IssueTracker.Exception;
 
-import com.CodeSquad.IssueTracker.Exception.user.InvalidCredentialException;
-import com.CodeSquad.IssueTracker.Exception.user.InvalidUserFormatException;
-import com.CodeSquad.IssueTracker.Exception.user.UserAlreadyExistsException;
-import com.CodeSquad.IssueTracker.Exception.user.UserNotLoginException;
+import com.CodeSquad.IssueTracker.Exception.milestone.InvalidMilestoneRequestException;
+import com.CodeSquad.IssueTracker.Exception.milestone.MilestoneNotFoundException;
+import com.CodeSquad.IssueTracker.Exception.user.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -17,18 +16,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
-    @ExceptionHandler(UserAlreadyExistsException.class)
-    public ResponseEntity<String> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
-    }
-
-    @ExceptionHandler(InvalidCredentialException.class)
-    public ResponseEntity<String> handleAuthenticationFailedException(InvalidCredentialException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
-    }
-
     @ExceptionHandler(UserNotLoginException.class)
     public ResponseEntity<String> handleUserNotLoginException(UserNotLoginException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidCredentialException.class)
+    public ResponseEntity<String> handleInvalidCredentialException(InvalidCredentialException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    //milestone
+    @ExceptionHandler(MilestoneNotFoundException.class)
+    public ResponseEntity<String> handleMilestoneNotFoundException(MilestoneNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidMilestoneRequestException.class)
+    public ResponseEntity<String> handleInvalidMilestoneRequestException(InvalidMilestoneRequestException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/milestone/InvalidMilestoneRequestException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/milestone/InvalidMilestoneRequestException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.milestone;
+
+public class InvalidMilestoneRequestException extends RuntimeException {
+    public InvalidMilestoneRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/milestone/MilestoneNotFoundException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/milestone/MilestoneNotFoundException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.milestone;
+
+public class MilestoneNotFoundException extends RuntimeException{
+    public MilestoneNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/user/UserAlreadyExistsException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/user/UserAlreadyExistsException.java
@@ -1,7 +1,0 @@
-package com.CodeSquad.IssueTracker.Exception.user;
-
-public class UserAlreadyExistsException extends RuntimeException {
-    public UserAlreadyExistsException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/user/UserNotFoundException.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/Exception/user/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.Exception.user;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/Milestone.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/Milestone.java
@@ -1,0 +1,29 @@
+package com.CodeSquad.IssueTracker.milestone;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.sql.Timestamp;
+
+@Setter
+@Getter
+@AllArgsConstructor
+
+@Table("milestone")
+public class Milestone {
+    @Id
+    private Long milestoneId;
+
+    private String title;
+
+    private String description;
+
+    private Timestamp deadline;
+
+    private Integer totalIssue;
+
+    private Integer closedIssue;
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneController.java
@@ -1,0 +1,41 @@
+package com.CodeSquad.IssueTracker.milestone;
+
+import com.CodeSquad.IssueTracker.milestone.dto.MilestoneRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class MilestoneController {
+    private final MilestoneService milestoneService;
+
+    public MilestoneController(MilestoneService milestoneService) {
+        this.milestoneService = milestoneService;
+    }
+
+    @PostMapping("/milestone")
+    public ResponseEntity<?> createMilestone(@RequestBody MilestoneRequest milestoneRequest) {
+        milestoneService.createMilestone(milestoneRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/milestones")
+    public ResponseEntity<List<Milestone>> getAllMilestones(){
+        List<Milestone> milestones = milestoneService.getAllMilestones();
+        return new ResponseEntity<>(milestones, HttpStatus.OK);
+    }
+
+    @GetMapping("/milestone/{milestoneId}")
+    public ResponseEntity<Milestone> getMilestone(@PathVariable Long milestoneId) {
+        Milestone milestone = milestoneService.getMilestoneById(milestoneId);
+        return new ResponseEntity<>(milestone, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/milestone/{milestoneId}")
+    public ResponseEntity<?> deleteMilestone(@PathVariable Long milestoneId) {
+        milestoneService.deleteMilestone(milestoneId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneRepository.java
@@ -1,0 +1,8 @@
+package com.CodeSquad.IssueTracker.milestone;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MilestoneRepository extends CrudRepository<Milestone, Long> {
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneService.java
@@ -1,0 +1,79 @@
+package com.CodeSquad.IssueTracker.milestone;
+
+import com.CodeSquad.IssueTracker.Exception.milestone.InvalidMilestoneRequestException;
+import com.CodeSquad.IssueTracker.Exception.milestone.MilestoneNotFoundException;
+import com.CodeSquad.IssueTracker.milestone.dto.MilestoneRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static com.CodeSquad.IssueTracker.milestone.utils.TimestampParser.parseDeadline;
+
+@Slf4j
+@Service
+public class MilestoneService {
+    private final MilestoneRepository milestoneRepository;
+
+    public MilestoneService(MilestoneRepository milestoneRepository) {
+        this.milestoneRepository = milestoneRepository;
+    }
+
+    public void createMilestone(MilestoneRequest milestoneRequest) {
+        log.info("마일스톤 생성 요청: {}", milestoneRequest);
+        validateMilestoneRequest(milestoneRequest);
+
+        Timestamp timestamp;
+        try {
+            timestamp= parseDeadline(milestoneRequest.getDeadline());
+        }catch (IllegalArgumentException  e){
+            log.error("마감일 형식이 잘못되었습니다: {}", milestoneRequest.getDeadline(), e);
+            throw new InvalidMilestoneRequestException("Invalid deadline format");
+        }
+
+        Milestone milestone = new Milestone(
+                milestoneRequest.getMilestoneId(),
+                milestoneRequest.getTitle(),
+                milestoneRequest.getDescription(),
+                timestamp,
+                milestoneRequest.getTotalIssue(),
+                milestoneRequest.getClosedIssue());
+
+        milestoneRepository.save(milestone);
+        log.info("마일스톤 생성 완료: {}", milestone);
+    }
+
+    public void deleteMilestone(Long milestoneId) {
+        log.info("마일스톤 삭제 요청: {}", milestoneId);
+        Milestone milestone = milestoneRepository.findById(milestoneId)
+                .orElseThrow(() -> {
+                    log.error("해당 마일스톤이 존재하지 않습니다: {}", milestoneId);
+                    return new MilestoneNotFoundException("해당 마일스톤이 존재하지 않습니다: " + milestoneId);
+                });
+
+        milestoneRepository.delete(milestone);
+        log.info("마일스톤 삭제 완료: {}", milestone);
+    }
+
+    public Milestone getMilestoneById(Long milestoneId) {
+        log.info("마일스톤 조회 요청: {}", milestoneId);
+        return milestoneRepository.findById(milestoneId)
+                .orElseThrow(() -> {
+                    log.error("해당 마일스톤이 존재하지 않습니다: {}", milestoneId);
+                    return new MilestoneNotFoundException("해당 마일스톤이 존재하지 않습니다: " + milestoneId);
+                });
+    }
+
+    public List<Milestone> getAllMilestones() {
+        log.info("전체 마일스톤 조회 요청");
+        return (List<Milestone>) milestoneRepository.findAll();
+    }
+
+    private void validateMilestoneRequest(MilestoneRequest milestoneRequest) {
+        if (milestoneRequest.getTitle().isEmpty()) {
+            log.error("제목이 비어있습니다: {}", milestoneRequest);
+            throw new InvalidMilestoneRequestException("제목이 비어있습니다");
+        }
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneRequest.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneRequest.java
@@ -1,0 +1,18 @@
+package com.CodeSquad.IssueTracker.milestone.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MilestoneRequest {
+    private Long milestoneId;
+
+    private String title;
+
+    private String description;
+
+    private String deadline;
+
+    private Integer totalIssue;
+
+    private Integer closedIssue;
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/utils/TimestampParser.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/utils/TimestampParser.java
@@ -1,0 +1,16 @@
+package com.CodeSquad.IssueTracker.milestone.utils;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimestampParser {
+    private static final DateTimeFormatter ISO_OFFSET_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+    public static Timestamp parseDeadline(String deadlineString) {
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse(deadlineString, ISO_OFFSET_DATE_TIME_FORMATTER);
+        Instant instant = offsetDateTime.toInstant();
+        return Timestamp.from(instant);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserController.java
@@ -2,7 +2,6 @@ package com.CodeSquad.IssueTracker.user;
 
 import com.CodeSquad.IssueTracker.user.dto.LoginRequest;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,40 +16,24 @@ public class UserController {
 
     @PostMapping("/registration")
     public ResponseEntity<?> registerNewUser(@RequestBody User user) {
-        if (userService.isUserNotExists(user)) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
-        if (userService.save(user)) {
-            return new ResponseEntity<>(HttpStatus.OK);
-        }
-
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        userService.save(user);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @PostMapping("/login")
     public ResponseEntity<?> loginUser(@RequestBody LoginRequest loginRequest,
                                        HttpServletRequest request) {
-        if (userService.isLoginRequestNotExists(loginRequest)) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-        String userId = loginRequest.getUserId();
-        String userPassword = loginRequest.getUserPassword();
+        userService.isLoginRequestNotExists(loginRequest);
+        userService.authenticate(loginRequest);
+        userService.addLoginSession(loginRequest, request.getSession());
 
-        if (userService.authenticate(userId, userPassword)) {
-            HttpSession session = request.getSession(true);
-            session.setMaxInactiveInterval(32400); //9시간
-            session.setAttribute("userId", userId);
-
-            return new ResponseEntity<>(HttpStatus.OK);
-        }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/validation/{id}")
     public ResponseEntity<?> getValidationId(@PathVariable("id") String id) {
         if (userService.isUserIdDuplicated(id)) {
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(HttpStatus.CONFLICT);
         }
 
         return new ResponseEntity<>(HttpStatus.OK);

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserService.java
@@ -1,7 +1,12 @@
 package com.CodeSquad.IssueTracker.user;
+import com.CodeSquad.IssueTracker.Exception.milestone.MilestoneNotFoundException;
+import com.CodeSquad.IssueTracker.Exception.user.InvalidCredentialException;
+import com.CodeSquad.IssueTracker.Exception.user.UserNotFoundException;
 import com.CodeSquad.IssueTracker.user.dto.LoginRequest;
 import com.CodeSquad.IssueTracker.Exception.user.InvalidUserFormatException;
 import com.CodeSquad.IssueTracker.user.utils.UserValidate;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,18 +25,14 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public boolean save(User user) {
+    public void save(User user) {
         log.info("사용자 저장 시도: {}", user.getUserId());
-
-        if (verifyUserInfo(user)) {
-            userRepository.save(user);
-            log.info("사용자 저장 성공: {}", user.getUserId());
-            return true;
-        }
-        return false;
+        verifyUserInfo(user);
+        userRepository.save(user);
+        log.info("사용자 저장 성공: {}", user.getUserId());
     }
 
-    public boolean verifyUserInfo(User user) {
+    public void verifyUserInfo(User user) {
         if (!UserValidate.isUserIdValid(user.getUserId())) {
             log.error("사용자 ID 유효성 검증 실패: {}", user.getUserId());
             throw new InvalidUserFormatException("ID가 형식에 맞지 않습니다.");
@@ -44,42 +45,40 @@ public class UserService {
             log.error("사용자 닉네임 유효성 검증 실패: {}", user.getUserId());
             throw new InvalidUserFormatException("닉네임이 형식에 맞지 않습니다.");
         }
-        return true;
     }
+
     public boolean isUserIdDuplicated(String userId) {
         Optional<User> userOptional = userRepository.findById(userId);
         return userOptional.isPresent();
     }
 
-    public boolean authenticate(String userId, String userPassword) {
-        Optional<User> userOptional = userRepository.findById(userId);
-        System.out.println(userOptional);
-        if (userOptional.isPresent()) {
-            if (Objects.equals(userOptional.get().getUserPassword(), userPassword)){
-                log.info("로그인 성공: {}", userId);
-                return true;
-            }
+    public void authenticate(LoginRequest loginRequest) {
+        String userId = loginRequest.getUserId();
+        String userPassword = loginRequest.getUserPassword();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("해당 유저가 존재하지 않습니다.: {}", userId);
+                    return new UserNotFoundException("해당 유저가 존재하지 않습니다.");
+                });
+
+        if (!Objects.equals(user.getUserPassword(), userPassword)){
+            log.warn("로그인 실패: {}", userId);
+            throw new InvalidCredentialException("아이디나 비밀번호가 맞지 않습니다.");
         }
-        log.warn("로그인 실패: {}", userId);
-        return false;
     }
 
-    public boolean isUserNotExists(User user) {
-        if (user == null){
-            log.warn("유저를 받아오지 못하였습니다.");
-            return true;
-        }
-        log.info("새 유저가 회원가입하였습니다.: {}", user);
-        return false;
+    public void addLoginSession(LoginRequest loginRequest, HttpSession session) {
+        session.setMaxInactiveInterval(32400); //9시간
+        session.setAttribute("userId", loginRequest.getUserId());
     }
 
-    public boolean isLoginRequestNotExists(LoginRequest loginRequest) {
+    public void isLoginRequestNotExists(LoginRequest loginRequest) {
         if (loginRequest == null){
             log.warn("로그인 실패: 로그인 데이터가 없습니다.");
-            return true;
+            throw new InvalidCredentialException("로그인 데이터가 없습니다.");
         }
         log.info("로그인 시도");
-        return false;
     }
 
 


### PR DESCRIPTION
더미데이터 삽입 후, 이슈 데이터를 리스트로 전달을 구현했습니다.

# 1. API
|HTTP 메소드|경로|설명|반환값|
|------|---|---|---|
|POST|/milestone|새 마일스톤 생성|정상 반환: OK|
|GET|/milestones|모든 마일스톤 조회|정상 반환: OK|
|GET|/milestone/{milestoneId}|지정된 ID의 마일스톤 조회|정상 반환: OK, 실패: NOT FOUND|
|DELETE|/milestone/{milestoneId}|지정된 ID의 마일스톤 삭제|정상 반환: OK|

# 2. 구현 Service 메소드 요약

## 모든 라벨 조회 (`getAllMilestones`)
- **메소드 설명**: 시스템에 저장된 모든 마일스톤을 조회합니다.
- **입력 파라미터**: 없음
- **반환 값**: `List<Milestone>` - 조회된 마일스톤 목록

## 마일스톤 ID로 조회 (`getMilestoneById`)
- **메소드 설명**: 주어진 ID를 가진 마일스톤을 조회합니다. ID가 유효하지 않은 경우 `MilestoneNotFoundException`을 발생시킵니다.
- **입력 파라미터**: `Long milestoneId` - 조회할 마일스톤의 ID
- **반환 값**: `Optional<Milestone>` - 조회된 마일스톤

## 마일스톤 생성 (`createMilestone`)
- **메소드 설명**: 새로운 마일스톤을 생성합니다.
- **입력 파라미터**: `Milestone milestone` - 생성할 마일스톤 정보
- **반환 값**: `Milestone ` - 생성된 마일스톤

## 마일스 삭제 (`deleteMilestone`)
- **메소드 설명**: 주어진 ID를 가진 마일스톤을 삭제합니다. 해당 ID의 마일스톤이 존재하지 않을 경우 `MilestoneNotFoundException`을 발생시킵니다.
- **입력 파라미터**: `Long milestoneId` - 삭제할 마일스톤의 ID
- **반환 값**: 없음