### PR TITLE
[미르] - 마일스톤 이슈

### DIFF
--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueController.java
@@ -1,9 +1,8 @@
 package com.CodeSquad.IssueTracker.issues;
 
-import com.CodeSquad.IssueTracker.issues.dto.IssueDetailResponse;
-import com.CodeSquad.IssueTracker.issues.dto.IssueIdResponse;
-import com.CodeSquad.IssueTracker.issues.dto.IssueRequest;
-import org.springframework.http.HttpStatus;
+import com.CodeSquad.IssueTracker.issues.dto.*;
+import com.CodeSquad.IssueTracker.milestone.Milestone;
+import com.CodeSquad.IssueTracker.milestone.MilestoneService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +21,7 @@ public class IssueController {
     @GetMapping("/issues")
     public ResponseEntity<List<Issue>> getAllIssues() {
         List<Issue> issues = issueService.getAllIssues();
-        return new ResponseEntity<>(issues, HttpStatus.OK);
+        return ResponseEntity.ok(issues);
     }
 
     @GetMapping("/issues/open")
@@ -47,20 +46,32 @@ public class IssueController {
     @GetMapping("/issue/{issueId}")
     public ResponseEntity<IssueDetailResponse> getIssue(@PathVariable("issueId") long issueId) {
         IssueDetailResponse issueDetailResponse = issueService.getIssueById(issueId);
-        return new ResponseEntity<>(issueDetailResponse, HttpStatus.OK);
+        return ResponseEntity.ok(issueDetailResponse);
     }
 
     @PatchMapping("/issue/{issueId}/open")
     public ResponseEntity<Issue> openIssue(@PathVariable("issueId") long issueId) {
         issueService.openIssue(issueId);
         Issue issue = issueService.findIssueById(issueId);
-        return new ResponseEntity<>(issue, HttpStatus.OK);
+        return ResponseEntity.ok(issue);
     }
 
     @PatchMapping("/issue/{issueId}/close")
     public ResponseEntity<Issue> closeIssue(@PathVariable("issueId") long issueId) {
         issueService.closeIssue(issueId);
         Issue issue = issueService.findIssueById(issueId);
-        return new ResponseEntity<>(issue, HttpStatus.OK);
+        return ResponseEntity.ok(issue);
+    }
+
+    @PatchMapping("/issue/{issueId}/title")
+    public ResponseEntity<?> editIssueTitle(@PathVariable("issueId") long issueId, @RequestBody IssueTitleRequest issueTitleRequest) {
+        issueService.updateIssueTitle(issueId, issueTitleRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping ("/issue/{issueId}/milestone")
+    public ResponseEntity<Milestone> editIssueMilestone(@PathVariable Long issueId, @RequestBody(required = false) IssueMilestoneRequest issueMilestoneRequest) {
+        Milestone milestone = issueService.updateMilestoneIdForIssue(issueId,issueMilestoneRequest);
+        return ResponseEntity.ok(milestone);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/IssueRepository.java
@@ -29,4 +29,16 @@ public interface IssueRepository extends CrudRepository<Issue, Long> {
 
     @Query("SELECT COUNT(issue_id) FROM issues WHERE is_closed = true")
     long countCloseIssues();
+
+    @Modifying
+    @Query("UPDATE issues SET title = :title WHERE issue_id = :issueId")
+    void updateIssueTitle(Long issueId, String title);
+
+    @Modifying
+    @Query("UPDATE issues SET milestone_id = :milestoneId WHERE issue_id = :issueId")
+    void updateMilestoneIdForIssue(Long issueId, Long milestoneId);
+
+    @Modifying
+    @Query("UPDATE issues SET milestone_id = NULL WHERE issue_id = :issueId")
+    void removeMilestoneFromIssue(Long issueId);
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueMilestoneRequest.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueMilestoneRequest.java
@@ -1,0 +1,4 @@
+package com.CodeSquad.IssueTracker.issues.dto;
+
+public record IssueMilestoneRequest(Long milestoneId)
+{ }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueTitleRequest.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/issues/dto/IssueTitleRequest.java
@@ -1,0 +1,4 @@
+package com.CodeSquad.IssueTracker.issues.dto;
+
+public record IssueTitleRequest(String title)
+{ }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/Milestone.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/Milestone.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Setter
 @Getter
@@ -19,20 +20,18 @@ public class Milestone {
 
     private String description;
 
-    private Timestamp deadline;
+    private LocalDateTime deadline;
 
-    private Integer totalIssue;
+    private Integer totalIssue = 0;
 
-    private Integer closedIssue;
+    private Integer closedIssue = 0;
 
     private Boolean isClosed = false;
 
-    public Milestone(Long milestoneId, String title, String description, Timestamp deadline, Integer totalIssue, Integer closedIssue) {
+    public Milestone(Long milestoneId, String title, String description, LocalDateTime deadline) {
         this.milestoneId = milestoneId;
         this.title = title;
         this.description = description;
         this.deadline = deadline;
-        this.totalIssue = totalIssue;
-        this.closedIssue = closedIssue;
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneController.java
@@ -1,7 +1,7 @@
 package com.CodeSquad.IssueTracker.milestone;
 
+import com.CodeSquad.IssueTracker.milestone.dto.MilestoneListResponse;
 import com.CodeSquad.IssueTracker.milestone.dto.MilestoneRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,48 +18,54 @@ public class MilestoneController {
     @PostMapping("/milestone")
     public ResponseEntity<?> createMilestone(@RequestBody MilestoneRequest milestoneRequest) {
         milestoneService.createMilestone(milestoneRequest);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/milestones/open")
     public ResponseEntity<List<Milestone>> getAllOpenMilestones(){
         List<Milestone> milestones = milestoneService.getOpenMilestones();
-        return new ResponseEntity<>(milestones, HttpStatus.OK);
+        return ResponseEntity.ok(milestones);
     }
 
     @GetMapping("/milestones/close")
     public ResponseEntity<List<Milestone>> getAllCloseMilestones(){
         List<Milestone> milestones = milestoneService.getCloseMilestones();
-        return new ResponseEntity<>(milestones, HttpStatus.OK);
+        return ResponseEntity.ok(milestones);
     }
 
     @GetMapping("/milestone/{milestoneId}")
     public ResponseEntity<Milestone> getMilestone(@PathVariable Long milestoneId) {
         Milestone milestone = milestoneService.getMilestoneById(milestoneId);
-        return new ResponseEntity<>(milestone, HttpStatus.OK);
+        return ResponseEntity.ok(milestone);
     }
 
     @DeleteMapping("/milestone/{milestoneId}")
     public ResponseEntity<?> deleteMilestone(@PathVariable Long milestoneId) {
         milestoneService.deleteMilestone(milestoneId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/milestone/{milestoneId}")
     public ResponseEntity<?> updateMilestone(@PathVariable Long milestoneId, @RequestBody MilestoneRequest milestoneRequest) {
         milestoneService.editMilestone(milestoneId, milestoneRequest);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping ("/milestone/{milestoneId}/open")
     public ResponseEntity<?> openMilestone(@PathVariable Long milestoneId ) {
         milestoneService.openMilestone(milestoneId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping ("/milestone/{milestoneId}/close")
     public ResponseEntity<?> closeMilestone(@PathVariable Long milestoneId ) {
         milestoneService.closeMilestone(milestoneId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping ("/milestone/list")
+    public ResponseEntity<List<MilestoneListResponse>> getMilestoneList() {
+        List<MilestoneListResponse> milestoneList = milestoneService.getOpenMilestoneList();
+        return ResponseEntity.ok(milestoneList);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneRepository.java
@@ -15,15 +15,26 @@ public interface MilestoneRepository extends CrudRepository<Milestone, Long> {
     @Query("SELECT * FROM milestone WHERE is_closed = 0")
     List<Milestone> findAllOpenMilestones();
 
+    @Query("SELECT * FROM milestone WHERE title = :title")
+    Milestone findByTitle(String title);
+
     @Modifying
     @Query("UPDATE milestone SET total_issue = total_issue + 1 WHERE milestone_id = :milestoneId")
-    void incrementIssueCountForMilestone(Long milestoneId);
+    void incrementTotalIssue(Long milestoneId);
+
+    @Modifying
+    @Query("UPDATE milestone SET total_issue = total_issue - 1 WHERE milestone_id = :milestoneId")
+    void decrementTotalIssue(Long milestoneId);
 
     @Modifying
     @Query("UPDATE milestone SET closed_issue = closed_issue + 1 WHERE milestone_id = :milestoneId")
-    void incrementClosedIssueCountForMilestone(Long milestoneId);
+    void incrementClosedIssue(Long milestoneId);
 
     @Modifying
     @Query("UPDATE milestone SET closed_issue = closed_issue - 1 WHERE milestone_id = :milestoneId")
-    void decrementClosedIssueCountForMilestone(Long milestoneId);
+    void decrementClosedIssue(Long milestoneId);
+
+    @Modifying
+    @Query("UPDATE issues SET milestone_id = NULL WHERE milestone_id = :milestoneId")
+    void deleteAllIssueReferences(Long milestoneId);
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/MilestoneService.java
@@ -2,11 +2,13 @@ package com.CodeSquad.IssueTracker.milestone;
 
 import com.CodeSquad.IssueTracker.Exception.milestone.InvalidMilestoneRequestException;
 import com.CodeSquad.IssueTracker.Exception.milestone.MilestoneNotFoundException;
+import com.CodeSquad.IssueTracker.milestone.dto.MilestoneListResponse;
 import com.CodeSquad.IssueTracker.milestone.dto.MilestoneRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.CodeSquad.IssueTracker.milestone.utils.TimestampParser.parseDeadline;
@@ -24,21 +26,20 @@ public class MilestoneService {
         log.info("마일스톤 생성 요청: {}", milestoneRequest);
         validateMilestoneRequest(milestoneRequest);
 
-        Timestamp timestamp;
+        LocalDateTime localDateTime;
         try {
-            timestamp= parseDeadline(milestoneRequest.getDeadline());
+            localDateTime= parseDeadline(milestoneRequest.deadline());
         }catch (IllegalArgumentException  e){
-            log.error("마감일 형식이 잘못되었습니다: {}", milestoneRequest.getDeadline(), e);
+            log.error("마감일 형식이 잘못되었습니다: {}", milestoneRequest.deadline(), e);
             throw new InvalidMilestoneRequestException("Invalid deadline format");
         }
 
         Milestone milestone = new Milestone(
-                milestoneRequest.getMilestoneId(),
-                milestoneRequest.getTitle(),
-                milestoneRequest.getDescription(),
-                timestamp,
-                milestoneRequest.getTotalIssue(),
-                milestoneRequest.getClosedIssue());
+                milestoneRequest.milestoneId(),
+                milestoneRequest.title(),
+                milestoneRequest.description(),
+                localDateTime
+        );
 
         milestoneRepository.save(milestone);
         log.info("마일스톤 생성 완료: {}", milestone);
@@ -48,6 +49,7 @@ public class MilestoneService {
         log.info("마일스톤 삭제 요청: {}", milestoneId);
         Milestone milestone = getMilestoneById(milestoneId);
 
+        milestoneRepository.deleteAllIssueReferences(milestoneId);
         milestoneRepository.delete(milestone);
         log.info("마일스톤 삭제 완료: {}", milestone);
     }
@@ -72,9 +74,12 @@ public class MilestoneService {
     }
 
     private void validateMilestoneRequest(MilestoneRequest milestoneRequest) {
-        if (milestoneRequest.getTitle().isEmpty()) {
+        if (milestoneRequest.title().isEmpty()) {
             log.error("제목이 비어있습니다: {}", milestoneRequest);
-            throw new InvalidMilestoneRequestException("제목이 비어있습니다");
+            throw new InvalidMilestoneRequestException("제목이 비어있습니다.");
+        }
+        if (milestoneRepository.findByTitle(milestoneRequest.title())!= null){
+            throw new InvalidMilestoneRequestException("같은 제목의 마일스톤이 존재합니다.");
         }
     }
 
@@ -83,9 +88,9 @@ public class MilestoneService {
         Milestone milestone = getMilestoneById(milestoneId);
 
         log.info("마일스톤 편집 milestone: {}", milestoneId);
-        milestone.setTitle(milestoneRequest.getTitle());
-        milestone.setDescription(milestoneRequest.getDescription());
-        milestone.setDeadline(parseDeadline(milestoneRequest.getDeadline()));
+        milestone.setTitle(milestoneRequest.title());
+        milestone.setDescription(milestoneRequest.description());
+        milestone.setDeadline(parseDeadline(milestoneRequest.deadline()));
 
         milestoneRepository.save(milestone);
     }
@@ -101,5 +106,40 @@ public class MilestoneService {
         milestone.setIsClosed(false);
         log.info("마일스톤 상태 변경 open milestone: {}", milestoneId);
         milestoneRepository.save(milestone);
+    }
+
+    public List<MilestoneListResponse> getOpenMilestoneList() {
+        List<Milestone> openMilestone = milestoneRepository.findAllOpenMilestones();
+        List<MilestoneListResponse> milestoneListResponse = new ArrayList<>();
+        log.info("열려있는 마일스톤 리스트로 조회");
+
+        for (Milestone milestone : openMilestone) {
+            milestoneListResponse.add (MilestoneListResponse.builder()
+                    .milestoneId(milestone.getMilestoneId())
+                    .title(milestone.getTitle())
+                    .build());
+        }
+
+        return milestoneListResponse;
+    }
+
+    public void incrementTotalIssue(Long milestoneId){
+        getMilestoneById(milestoneId);
+        milestoneRepository.incrementTotalIssue(milestoneId);
+    }
+
+    public void decrementTotalIssue(Long milestoneId){
+        getMilestoneById(milestoneId);
+        milestoneRepository.decrementTotalIssue(milestoneId);
+    }
+
+    public void incrementClosedIssue(Long milestoneId){
+        getMilestoneById(milestoneId);
+        milestoneRepository.incrementClosedIssue(milestoneId);
+    }
+
+    public void decrementClosedIssue(Long milestoneId){
+        getMilestoneById(milestoneId);
+        milestoneRepository.decrementClosedIssue(milestoneId);
     }
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneListResponse.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneListResponse.java
@@ -1,0 +1,7 @@
+package com.CodeSquad.IssueTracker.milestone.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MilestoneListResponse (Long milestoneId, String title)
+{ }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneRequest.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/dto/MilestoneRequest.java
@@ -1,18 +1,6 @@
 package com.CodeSquad.IssueTracker.milestone.dto;
 
-import lombok.Getter;
-
-@Getter
-public class MilestoneRequest {
-    private Long milestoneId;
-
-    private String title;
-
-    private String description;
-
-    private String deadline;
-
-    private Integer totalIssue;
-
-    private Integer closedIssue;
-}
+public record MilestoneRequest(Long milestoneId, String title,
+                               String description, String deadline,
+                               Integer totalIssue, Integer closedIssue)
+{ }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/utils/TimestampParser.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/milestone/utils/TimestampParser.java
@@ -2,15 +2,14 @@ package com.CodeSquad.IssueTracker.milestone.utils;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class TimestampParser {
     private static final DateTimeFormatter ISO_OFFSET_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
-    public static Timestamp parseDeadline(String deadlineString) {
-        OffsetDateTime offsetDateTime = OffsetDateTime.parse(deadlineString, ISO_OFFSET_DATE_TIME_FORMATTER);
-        Instant instant = offsetDateTime.toInstant();
-        return Timestamp.from(instant);
+    public static LocalDateTime parseDeadline(String deadlineString) {
+        return LocalDateTime.parse(deadlineString, ISO_OFFSET_DATE_TIME_FORMATTER);
     }
 }


### PR DESCRIPTION
# 1. API

| HTTP 메소드 | 경로 | 설명 | 반환값 |
| --- | --- | --- | --- |
| PATCH| /issue/{issueId}/title | 이슈의 제목 수정 | 정상 반환: 200 OK |
| PATCH| /issue/{issueId}/milestone | 이슈의 마일스톤 | 정상 반환: 200 OK |
| GET | /milestone/list| 모든 마일스톤 목록 반환 | 정상 반환: 200 OK |

# 2. 구현 Service 메소드 요약

## 모든 열 마일스톤 조회 (`getOpenMilestoneList`)

- **메소드 설명**: 모든 열려있는 마일스톤을 가져온다.
- **입력 파라미터**: 없음
- **반환 값**: `List<Label>` - 조회된 마일스톤 목록

## 이슈의 갯수를 변경 (`incrementTotalIssue, decrementTotalIssue, incrementClosedIssue, decrementClosedIssue`)

- **메소드 설명**:  해당하는 milestoneId 에 접속하여 이슈의 갯수를 변경합니다.
- **입력 파라미터**: `Long milestoneId` - 조회할 마일스톤의 ID
- **반환 값**: 없음

## 이슈의 마일스톤을 변경 (`updateMilestoneIdForIssue`)

- **메소드 설명**: 해당하는 이슈의 마일스톤을 원하는 마일스톤으로 변경합니다.
- **입력 파라미터**: `Long issueId, IssueMilestoneRequest, issueMilestoneRequest` - 조회할 이슈, 마일스톤
- **반환 값**:  바뀐 마일스톤