### PR TITLE
[Kalia] - Github Oauth 로직 추가

### DIFF
--- a/backend/src/main/java/com/CodeSquad/IssueTracker/config/MvcConfig.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/config/MvcConfig.java
@@ -18,10 +18,11 @@ public class MvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+
         registry.addInterceptor(new CheckLoginInterceptor(jwtUtil))
             .order(1)
             .addPathPatterns("/**")
-            .excludePathPatterns("/login", "/registration/**");
+            .excludePathPatterns("/login", "/registration/**", "/issue/check", "/auth/github/**", "/favicon.ico", "/error");
     }
 
     @Override

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/interceptor/CheckLoginInterceptor.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/interceptor/CheckLoginInterceptor.java
@@ -22,18 +22,24 @@ public class CheckLoginInterceptor implements HandlerInterceptor {
             return true; // OPTIONS 요청은 바로 통과시킴
         }
 
+
 //        HttpSession session = request.getSession();
 //        if (session.getAttribute("userId") == null) {
 //            throw new UserNotLoginException("로그인이 필요합니다.");
 //        }
 
-        String token = request.getHeader("Authorization");
-        if (token == null || !token.startsWith("Bearer ")) {
-            throw new UserNotLoginException("토큰이 없거나 잘못되었습니다.");
+
+        String token = jwtUtil.getTokenFromHeader(request);
+        if (token == null) {
+
+            throw new UserNotLoginException("토큰이 없습니다.");
+
         }
 
         try {
-            String userId = jwtUtil.validateToken(token.substring(7));
+            String userId = jwtUtil.validateToken(token);
+            // 토큰 검증 성공 시 추가 작업 수행 (예: 사용자 정보 설정 등)
+            request.setAttribute("userId", userId);
         } catch (Exception e) {
             throw new UserNotLoginException("토큰이 유효하지 않습니다.");
         }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/User.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/User.java
@@ -4,8 +4,10 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+@Setter
 @Getter
 @Builder
 @NoArgsConstructor
@@ -19,7 +21,6 @@ public class User implements Persistable<String> {
 
     @Transient
     private boolean isNew = true;
-
     @Override
     public String getId() {
         return userId;

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserRepository.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -14,4 +15,6 @@ public interface UserRepository extends CrudRepository<User, String> {
 
     @Query("SELECT user_id FROM users")
     List<String> getAllUserIds();
+
+    Optional<User> findById(String userId);
 }

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/AppConfig.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/AppConfig.java
@@ -1,0 +1,13 @@
+package com.CodeSquad.IssueTracker.user.gitLogin;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/GitHubOAuthController.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/GitHubOAuthController.java
@@ -1,0 +1,39 @@
+package com.CodeSquad.IssueTracker.user.gitLogin;
+
+import com.CodeSquad.IssueTracker.user.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/auth/github")
+public class GitHubOAuthController {
+    private final GitHubOauthService gitHubOauthService;
+
+    public GitHubOAuthController(GitHubOauthService gitHubOauthService) {
+        this.gitHubOauthService = gitHubOauthService;
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<Void> githubLogin(@Value("${github.client.id}") String clientId) {
+        String redirectUrl = "https://github.com/login/oauth/authorize?client_id=" + clientId;
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(redirectUrl)).build();
+    }
+
+    @GetMapping("/callback")
+    public ResponseEntity<String> githubCallback(@RequestParam("code") String code) {
+        String accessToken = gitHubOauthService.getAccessToken(code);
+        String gitHubUserId = gitHubOauthService.getUserLogin(accessToken);
+
+        User user = gitHubOauthService.saveUserAndGenerateToken(gitHubUserId, accessToken);
+        String jwtToken = gitHubOauthService.generateJwtToken(user);
+
+        return ResponseEntity.ok(jwtToken);
+    }
+}

--- a/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/GitHubOauthService.java
+++ b/backend/src/main/java/com/CodeSquad/IssueTracker/user/gitLogin/GitHubOauthService.java
@@ -1,0 +1,106 @@
+package com.CodeSquad.IssueTracker.user.gitLogin;
+
+import com.CodeSquad.IssueTracker.user.User;
+import com.CodeSquad.IssueTracker.user.UserRepository;
+import com.CodeSquad.IssueTracker.user.jwtlogin.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class GitHubOauthService {
+    private final String clientId;
+    private final String clientSecret;
+    private final RestTemplate restTemplate;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final ConcurrentHashMap<String, String> accessTokenCache = new ConcurrentHashMap<>();
+
+    public GitHubOauthService(@Value("${github.client.id}") String clientId,
+                              @Value("${github.client.secret}") String clientSecret,
+                              RestTemplate restTemplate, JwtUtil jwtUtil, UserRepository userRepository) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.restTemplate = restTemplate;
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    public String getAccessToken(String code) {
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("client_id", clientId);
+        body.put("client_secret", clientSecret);
+        body.put("code", code);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_FORM_URLENCODED));
+
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity("https://github.com/login/oauth/access_token", entity, String.class);
+        String[] responseParts = response.getBody().split("&");
+        String accessToken = null;
+
+        for (String part : responseParts) {
+            if (part.startsWith("access_token=")) {
+                accessToken = part.split("=")[1];
+                break;
+            }
+        }
+
+        return accessToken;
+    }
+
+    public String getUserLogin(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://api.github.com/user",
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        return response.getBody().get("login").toString();
+    }
+
+    public User saveUserAndGenerateToken(String gitHubUserId, String gitHubAccessToken) {
+        String existingAccessToken = accessTokenCache.get(gitHubUserId);
+
+        User user;
+        if (existingAccessToken == null || !existingAccessToken.equals(gitHubAccessToken)) {
+            accessTokenCache.put(gitHubUserId, gitHubAccessToken);
+            user = User.builder()
+                    .userId(gitHubUserId)
+                    .isNew(existingAccessToken == null)
+                    .build();
+            user = userRepository.save(user); // 새로운 사용자 추가 또는 기존 사용자 조회
+        } else {
+            user = userRepository.findById(gitHubUserId).orElse(null); // 기존 사용자 조회
+            if (user == null) {
+                user = User.builder()
+                        .userId(gitHubUserId)
+                        .isNew(false)
+                        .build();
+                user = userRepository.save(user); // 새로운 사용자 추가
+            }
+        }
+
+        return user;
+    }
+
+    public String generateJwtToken(User user) {
+        return jwtUtil.generateToken(user.getUserId());
+    }
+}
+

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
+github:
+  client:
+    id: Ov23liO8Ca6R78HtYa0U
+    secret: 37fd4d8254de51ea8eb7e8a09059c8f143794460
+
 server:
   servlet:
     session:


### PR DESCRIPTION
# 1. API

| HTTP 메소드 | 경로                                | 설명                      | 반환값               |
|-------------|-------------------------------------|---------------------------|----------------------|
| GET         | /auth/github/login                  | GitHub OAuth 로그인 페이지로 리다이렉트 | 302 Found            |
| GET         | /auth/github/callback?code={code}   | GitHub OAuth 콜백 처리, JWT 토큰 발급  | 200 OK, JWT 토큰    |

# 2. GitHubOAuthController

## `githubLogin` 메소드

- **HTTP 메소드**: `GET`
- **경로**: `/auth/github/login`
- **설명**: GitHub OAuth 로그인 페이지로 리다이렉트합니다.
- **입력 파라미터**: 
  - `clientId` (`@Value("${github.client.id}")`) - GitHub 클라이언트 ID
- **반환값**: `ResponseEntity<Void>` - 302 Found 상태 코드와 리다이렉트 URL

## `githubCallback` 메소드

- **HTTP 메소드**: `GET`
- **경로**: `/auth/github/callback`
- **설명**: GitHub OAuth 콜백을 처리하고 JWT 토큰을 발급합니다.
- **입력 파라미터**:
  - `code` (`@RequestParam("code")`) - GitHub OAuth 인증 코드
- **반환값**: `ResponseEntity<String>` - 200 OK 상태 코드와 JWT 토큰

# 3. GitHubOauthService

## `getAccessToken` 메소드

- **설명**: GitHub OAuth 인증 코드를 사용하여 액세스 토큰을 가져옵니다.
- **입력 파라미터**: `code` - GitHub OAuth 인증 코드
- **반환값**: `String` - GitHub 액세스 토큰

## `getUserLogin` 메소드

- **설명**: GitHub 액세스 토큰을 사용하여 사용자 로그인 ID를 가져옵니다.
- **입력 파라미터**: `accessToken` - GitHub 액세스 토큰
- **반환값**: `String` - GitHub 사용자 로그인 ID

## `saveUserAndGenerateToken` 메소드

- **설명**: GitHub 사용자 ID와 액세스 토큰을 사용하여 사용자를 저장하고 JWT 토큰을 생성합니다.
- **입력 파라미터**:
  - `gitHubUserId` - GitHub 사용자 ID
  - `gitHubAccessToken` - GitHub 액세스 토큰
- **반환값**: `User` - 저장된 사용자 객체

## `generateJwtToken` 메소드

- **설명**: 사용자 ID를 사용하여 JWT 토큰을 생성합니다.
- **입력 파라미터**: `user` - 사용자 객체
- **반환값**: `String` - JWT 토큰
